### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mdlew/ip/security/code-scanning/2](https://github.com/mdlew/ip/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- `actions/checkout` requires `contents: read` to check out the repository.
- `cloudflare/wrangler-action` may require `contents: read` to access repository files and `secrets` to use the provided secrets.

We will set `contents: read` as the minimal permission and ensure no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
